### PR TITLE
[op][agl][wayland] Drop window surface ID

### DIFF
--- a/src/webos/agl/webapp_window_base_agl.cc
+++ b/src/webos/agl/webapp_window_base_agl.cc
@@ -75,7 +75,5 @@ void WebAppWindowBaseAgl::SetAglPanel(int edge) {
     webapp_window->SetAglPanel(edge);
 }
 
-void WebAppWindowBaseAgl::SetWindowSurfaceId(int surface_id) {}
-
 }  // namespace agl
 }  // namespace webos

--- a/src/webos/agl/webapp_window_base_agl.h
+++ b/src/webos/agl/webapp_window_base_agl.h
@@ -42,7 +42,6 @@ class WEBOS_EXPORT WebAppWindowBaseAgl {
   void SetAglBackground();
   void SetAglReady();
   void SetAglPanel(int edge);
-  void SetWindowSurfaceId(int surface_id);
 
  private:
   WebAppWindowBase* webapp_window_base_;

--- a/src/webos/agl/webapp_window_base_agl_stub.cc
+++ b/src/webos/agl/webapp_window_base_agl_stub.cc
@@ -36,7 +36,5 @@ void WebAppWindowBaseAgl::SetAglReady() {}
 
 void WebAppWindowBaseAgl::SetAglPanel(int edge) {}
 
-void WebAppWindowBaseAgl::SetWindowSurfaceId(int surface_id) {}
-
 }  // namespace agl
 }  // namespace webos


### PR DESCRIPTION
Window surface ID is not used anymore in AGL compositor. Drop passing
it from WAM (that was obtained from PID).

Bug-AGL: SPEC-4252
Signed-off-by: Jose Dapena Paz <jdapena@igalia.com>