### PR TITLE
[op][wayland] Add Wayland protocol version checking

### DIFF
--- a/src/ui/ozone/platform/wayland/common/wayland_object.cc
+++ b/src/ui/ozone/platform/wayland/common/wayland_object.cc
@@ -22,6 +22,8 @@
 #include <xdg-shell-client-protocol.h>
 #include <xdg-shell-unstable-v6-client-protocol.h>
 
+#include "base/logging.h"
+
 namespace wl {
 namespace {
 
@@ -131,6 +133,25 @@ const wl_interface* ObjectTraits<wl_compositor>::interface =
     &wl_compositor_interface;
 void (*ObjectTraits<wl_compositor>::deleter)(wl_compositor*) =
     &wl_compositor_destroy;
+
+bool CanBind(const std::string& interface,
+             uint32_t available_version,
+             uint32_t min_version,
+             uint32_t max_version) {
+  if (available_version < min_version) {
+    LOG(WARNING) << "Unable to bind to " << interface << " version "
+                 << available_version << ".  The minimum supported version is "
+                 << min_version << ".";
+    return false;
+  }
+
+  if (available_version > max_version) {
+    LOG(WARNING) << "Binding to " << interface << " version " << max_version
+                 << " but version " << available_version << " is available.";
+  }
+
+  return true;
+}
 
 void (*ObjectTraits<wl_cursor_theme>::deleter)(wl_cursor_theme*) =
     &wl_cursor_theme_destroy;

--- a/src/ui/ozone/platform/wayland/common/wayland_object.h
+++ b/src/ui/ozone/platform/wayland/common/wayland_object.h
@@ -472,6 +472,17 @@ wl::Object<T> Bind(wl_registry* registry, uint32_t name, uint32_t version) {
       registry, name, ObjectTraits<T>::interface, version));
 }
 
+// Checks the given |available_version| exposed by the server against
+// |min_version| and |max_version| supported by the client.
+// Returns false (with rendering a warning) if |available_version| is less than
+// the minimum supported version.
+// Returns true otherwise, renders an info message if |available_version| is
+// greater than the maximum supported one.
+bool CanBind(const std::string& interface,
+             uint32_t available_version,
+             uint32_t min_version,
+             uint32_t max_version);
+
 }  // namespace wl
 
 #endif  // UI_OZONE_PLATFORM_WAYLAND_COMMON_WAYLAND_OBJECT_H_

--- a/src/ui/ozone/platform/wayland/extensions/agl/host/wayland_extensions_agl_impl.cc
+++ b/src/ui/ozone/platform/wayland/extensions/agl/host/wayland_extensions_agl_impl.cc
@@ -37,6 +37,7 @@ namespace ui {
 
 namespace {
 
+constexpr uint32_t kMinAglShellExtensionVersion = 1;
 constexpr uint32_t kMaxAglShellExtensionVersion = 1;
 
 }  // namespace
@@ -54,9 +55,12 @@ bool WaylandExtensionsAglImpl::Bind(wl_registry* registry,
   bool should_use_agl_shell =
       base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kAglShellAppId);
 
-  if (should_use_agl_shell && !agl_shell_ && (strcmp(interface, "agl_shell") == 0)) {
-    wl::Object<agl_shell> aglshell =
-        wl::Bind<agl_shell>(registry, name, kMaxAglShellExtensionVersion);
+  if (should_use_agl_shell && !agl_shell_ &&
+      (strcmp(interface, "agl_shell") == 0) &&
+      wl::CanBind(interface, version, kMinAglShellExtensionVersion,
+                  kMaxAglShellExtensionVersion)) {
+    wl::Object<agl_shell> aglshell = wl::Bind<agl_shell>(
+        registry, name, std::min(version, kMaxAglShellExtensionVersion));
     if (!aglshell) {
       LOG(ERROR) << "Failed to bind to agl_shell global";
       return false;


### PR DESCRIPTION
Make sure we bind with a protocol version we actually support. This
adds checks for minimum and maximum version we support, and binds
to the minimum of the wayland server version and the maximum we
support.

Based on upstream commit:
    commit dd4c3ddadbb9869f59cee201a38e9ca3b9154f4d
    Author: Alexander Dunaev <adunaev@igalia.com>
    Date:   Tue Dec 14 09:54:52 2021 +0000

    [linux/wayland] Fixed terminate caused by binding to wrong version.

Bug-AGL: TODO
Signed-off-by: Jose Dapena Paz <jdapena@igalia.com>