### PR TITLE
[agl] Ignore certificate errors when using the agl-devel

### DIFF
--- a/src/neva/BUILD.gn
+++ b/src/neva/BUILD.gn
@@ -67,6 +67,10 @@ config("config") {
     defines += [ "IS_AGL=1" ]
   }
 
+  if (is_agl_devel) {
+    defines += [ "IS_AGL_DEVEL=1" ]
+  }
+
   if (use_neva_appruntime) {
     defines += [ "USE_NEVA_APPRUNTIME=1" ]
   }

--- a/src/neva/neva.gni
+++ b/src/neva/neva.gni
@@ -19,6 +19,7 @@
 declare_args() {
   # AGL chromium%.bb recipe uses it
   is_agl = false
+  is_agl_devel = false
 }
 
 declare_args() {

--- a/src/webos/app/webos_content_main_delegate.cc
+++ b/src/webos/app/webos_content_main_delegate.cc
@@ -21,6 +21,7 @@
 #include "base/lazy_instance.h"
 #include "base/logging.h"
 #include "base/path_service.h"
+#include "components/network_session_configurator/common/network_switches.h"
 #include "components/viz/common/switches.h"
 #include "content/public/common/content_switches.h"
 #include "neva/app_runtime/browser/app_runtime_content_browser_client.h"
@@ -56,12 +57,17 @@ bool WebOSContentMainDelegate::BasicStartupComplete(int* exit_code) {
       false /* enable_timestamp */, false /* enable_tickcount */);
 
   parsedCommandLine->AppendSwitchASCII(switches::kUseVizFMPWithTimeout, "0");
+
+#if defined(IS_AGL_DEVEL)
+  parsedCommandLine->AppendSwitch(switches::kIgnoreCertificateErrors);
+#endif
+
 #if defined(USE_PMLOG)
   logging::PmLogProvider::Initialize("wam");
 #endif
 
   std::string process_type =
-        parsedCommandLine->GetSwitchValueASCII(switches::kProcessType);
+      parsedCommandLine->GetSwitchValueASCII(switches::kProcessType);
   if (process_type.empty()) {
     startup_callback_.Run();
   }
@@ -92,8 +98,7 @@ WebOSContentMainDelegate::CreateContentRendererClient() {
   return content_renderer_client_.get();
 }
 
-content::ContentClient*
-WebOSContentMainDelegate::CreateContentClient() {
+content::ContentClient* WebOSContentMainDelegate::CreateContentClient() {
   content_client_ = std::make_unique<WebOSContentClient>();
   neva_app_runtime::SetAppRuntimeContentClient(content_client_.get());
   return content_client_.get();


### PR DESCRIPTION
This is needed because websocket secure connections will fail with self-signed certificates used for services during development.

Chromium recipe needs to add the is_agl_devel = true to gn args.