### PR TITLE
[agl][wayland] Update agl-shell protocol to version 3

### DIFF
--- a/src/ui/ozone/platform/wayland/extensions/agl/host/agl_shell_wrapper.h
+++ b/src/ui/ozone/platform/wayland/extensions/agl/host/agl_shell_wrapper.h
@@ -37,11 +37,16 @@ class AglShellWrapper {
   void SetAglPanel(WaylandWindow* window, uint32_t edge);
   void SetAglBackground(WaylandWindow* window);
   void SetAglReady();
+  bool WaitUntilBoundOk();
+
+  static void AglShellBoundOk(void* data, struct agl_shell*);
+  static void AglShellBoundFail(void* data, struct agl_shell*);
 
  private:
   wl::Object<agl_shell> agl_shell_;
-
   WaylandConnection* connection_;
+  bool wait_for_bound_ = true;
+  bool bound_ok_ = false;
 };
 
 }  // namespace ui

--- a/src/ui/ozone/platform/wayland/extensions/agl/host/agl_shell_wrapper.h
+++ b/src/ui/ozone/platform/wayland/extensions/agl/host/agl_shell_wrapper.h
@@ -19,6 +19,8 @@
 
 #include <string>
 
+#include <agl-shell-client-protocol.h>
+
 #include "ui/ozone/platform/wayland/extensions/agl/common/wayland_object_agl.h"
 
 namespace ui {
@@ -41,6 +43,12 @@ class AglShellWrapper {
 
   static void AglShellBoundOk(void* data, struct agl_shell*);
   static void AglShellBoundFail(void* data, struct agl_shell*);
+#ifdef AGL_SHELL_APP_STATE_SINCE_VERSION
+  static void AglAppState(void* data,
+                          struct agl_shell*,
+                          const char* app_id,
+                          uint32_t state);
+#endif
 
  private:
   wl::Object<agl_shell> agl_shell_;

--- a/src/ui/ozone/platform/wayland/extensions/agl/host/wayland_extensions_agl_impl.cc
+++ b/src/ui/ozone/platform/wayland/extensions/agl/host/wayland_extensions_agl_impl.cc
@@ -38,7 +38,7 @@ namespace ui {
 namespace {
 
 constexpr uint32_t kMinAglShellExtensionVersion = 1;
-constexpr uint32_t kMaxAglShellExtensionVersion = 1;
+constexpr uint32_t kMaxAglShellExtensionVersion = 2;
 
 }  // namespace
 
@@ -52,8 +52,8 @@ bool WaylandExtensionsAglImpl::Bind(wl_registry* registry,
                                     uint32_t name,
                                     const char* interface,
                                     uint32_t version) {
-  bool should_use_agl_shell =
-      base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kAglShellAppId);
+  bool should_use_agl_shell = base::CommandLine::ForCurrentProcess()->HasSwitch(
+      switches::kAglShellAppId);
 
   if (should_use_agl_shell && !agl_shell_ &&
       (strcmp(interface, "agl_shell") == 0) &&
@@ -67,7 +67,8 @@ bool WaylandExtensionsAglImpl::Bind(wl_registry* registry,
     }
     agl_shell_ =
         std::make_unique<AglShellWrapper>(aglshell.release(), connection_);
-    return true;
+
+    return agl_shell_->WaitUntilBoundOk();
   }
 
   return false;

--- a/src/ui/ozone/platform/wayland/extensions/agl/host/wayland_extensions_agl_impl.cc
+++ b/src/ui/ozone/platform/wayland/extensions/agl/host/wayland_extensions_agl_impl.cc
@@ -38,7 +38,7 @@ namespace ui {
 namespace {
 
 constexpr uint32_t kMinAglShellExtensionVersion = 1;
-constexpr uint32_t kMaxAglShellExtensionVersion = 2;
+constexpr uint32_t kMaxAglShellExtensionVersion = 3;
 
 }  // namespace
 

--- a/src/ui/ozone/platform/wayland/extensions/agl/protocol/agl-shell.xml
+++ b/src/ui/ozone/platform/wayland/extensions/agl/protocol/agl-shell.xml
@@ -22,7 +22,7 @@
     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
     DEALINGS IN THE SOFTWARE.
   </copyright>
-  <interface name="agl_shell" version="2">
+  <interface name="agl_shell" version="3">
     <description summary="user interface for Automotive Grade Linux platform">
       Starting with version 2 of the protocol, the client is required to wait
       for the 'bound_ok' or 'bound_fail' events in order to proceed further.
@@ -58,6 +58,13 @@
       <entry name="bottom" value="1"/>
       <entry name="left" value="2"/>
       <entry name="right" value="3"/>
+    </enum>
+
+    <enum name="app_state" since="3">
+      <entry name="started" value="0"/>
+      <entry name="terminated" value="1"/>
+      <entry name="activated" value="2"/>
+      <entry name="deactivated" value="3"/>
     </enum>
 
     <request name="ready">
@@ -155,6 +162,18 @@
       <description summary="destroys the factory object">
       </description>
     </request>
+
+    <event name="app_state" since="3">
+      <description summary="event sent when an application suffered state modification">
+        Informs the client that an application has changed its state to another,
+        specified by the app_state enum. Client can use this event to track
+        current application state. For instance to know when the application has
+        started, or when terminated/stopped.
+      </description>
+      <arg name="app_id" type="string"/>
+      <arg name="state" type="uint" enum="app_state"/>
+    </event>
+
 
   </interface>
 </protocol>

--- a/src/ui/ozone/platform/wayland/extensions/agl/protocol/agl-shell.xml
+++ b/src/ui/ozone/platform/wayland/extensions/agl/protocol/agl-shell.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <protocol name="agl_shell">
   <copyright>
-    Copyright © 2019 Collabora, Ltd.
+    Copyright © 2019, 2022 Collabora, Ltd.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -22,8 +22,29 @@
     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
     DEALINGS IN THE SOFTWARE.
   </copyright>
-  <interface name="agl_shell" version="1">
-    <description summary="user interface for weston-ivi">
+  <interface name="agl_shell" version="2">
+    <description summary="user interface for Automotive Grade Linux platform">
+      Starting with version 2 of the protocol, the client is required to wait
+      for the 'bound_ok' or 'bound_fail' events in order to proceed further.
+
+      In case the client gets a 'bound_fail' event then it should consider that
+      there's another client already bound to the agl_shell protocol.
+      A client that receives a 'bound_ok' event should consider that there's
+      no other client already bound to the interface and can proceed further.
+
+      If the client uses an older version of the protocol it will receive
+      automatically an error and the compositor will terminate the connection,
+      if there's another client already bound the interface.
+
+      If the client receives the 'bound_fail' event and attempts to use the
+      interface further it will receive an error and the compositor will
+      terminate the connection. After the 'bound_fail' event was received the
+      client should call the destructor, which has been added with version 2
+      of the protocol. The client is free to try at a later point in time to
+      see if it will receive the 'bound_ok' event, but there's no explicit way
+      of finding out when that event will be delivered.
+      It is assumed that it can infer that information through other
+      means/other channels.
     </description>
 
     <enum name="error">
@@ -44,7 +65,7 @@
         Tell the server that this client is ready to be shown. The server
         will delay presentation during start-up until all shell clients are
         ready to be shown, and will display a black screen instead.
-        This gives the client an oppurtunity to set up and configure several
+        This gives the client an opportunity to set up and configure several
         surfaces into a coherent interface.
 
         The client that binds to this interface must send this request, otherwise
@@ -76,7 +97,7 @@
         Set the surface to act as a panel of an output. The 'edge' argument
         says what edge of the output the surface will be anchored to.
         After this request, the server will send a configure event with the
-        correponding width/height that the client should use, and 0 for the
+        corresponding width/height that the client should use, and 0 for the
         other dimension. E.g. if the edge is 'top', the width will be the
         output's width, and the height will be 0.
 
@@ -99,11 +120,11 @@
 
     <request name="activate_app">
       <description summary="make client current window">
-        Asks the compositor to make a toplevel to become the current/focued
+        Ask the compositor to make a toplevel to become the current/focused
         window for window management purposes.
 
         See xdg_toplevel.set_app_id from the xdg-shell protocol for a
-        description app_id.
+        description of app_id.
 
         If multiple toplevels have the same app_id, the result is unspecified.
 
@@ -113,5 +134,27 @@
       <arg name="app_id" type="string"/>
       <arg name="output" type="object" interface="wl_output"/>
     </request>
+
+    <event name="bound_ok" since="2">
+     <description summary="event sent if binding was ok">
+        Informs the client that it was able to bind the agl_shell
+        interface succesfully. Clients are required to wait for this
+        event before continuing further.
+     </description>
+    </event>
+
+    <event name="bound_fail" since="2">
+      <description summary="event sent if binding was nok">
+        Informs the client that binding to the agl_shell interface was
+        unsuccesfull. Clients are required to wait for this event for
+        continuing further.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor" since="2">
+      <description summary="destroys the factory object">
+      </description>
+    </request>
+
   </interface>
 </protocol>


### PR DESCRIPTION
This pull request includes the following changes:

- [agl][wayland] Update agl-shell protocol to version 2
Now clients need to wait for the bound_ok event to continue. From the
protocol documentation:

"Starting with version 2 of the protocol, the client is required to wait
for the 'bound_ok' or 'bound_fail' events in order to proceed further.

In case the client gets a 'bound_fail' event then it should consider that
there's another client already bound to the agl_shell protocol.
A client that receives a 'bound_ok' event should consider that there's
no other client already bound to the interface and can proceed
further."

- [agl][wayland] Update agl-shell protocol to version 3
The protocol change provides an event to listen to application state
changes.

This change includes activating the application when the app_state
event receives a "start" event for it.

A change on html5 recipe will be needed to disable default activation on
compositor side.

- Those changes are needed to update wam to catch up with the current state of agl shell protocol.